### PR TITLE
sendMessage() returns a string, the message id

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -251,7 +251,7 @@ export default class Client extends EventEmitter {
         }
     }
 
-    public sendMessage(data: Message) {
+    public sendMessage(data: Message): string {
         const id = data.id || this.nextId();
         const msg = {
             id,

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,7 @@ export interface Agent extends StrictEventEmitter<EventEmitter, AgentEvents> {
     sendIQ<T = IQ, R = T>(iq: T & IQ): Promise<IQ & R>;
     sendIQResult(orig: IQ, result?: Partial<IQ>): void;
     sendIQError(orig: IQ, err?: Partial<IQ>): void;
-    sendMessage(msg: Message): void;
+    sendMessage(msg: Message): string;
     sendPresence(pres?: Presence): void;
     sendStreamError(err: StreamError): void;
 }


### PR DESCRIPTION
The annotation for sendMessage is out of step with the behaviour, I've assumed that the preferred outcome is to return the message id.