### PR TITLE
fix sasl priorities from getting messed up

### DIFF
--- a/src/lib/sasl/index.ts
+++ b/src/lib/sasl/index.ts
@@ -98,7 +98,7 @@ export class Factory {
         this.mechanisms.push({
             constructor,
             name: name.toUpperCase(),
-            priority: priority || this.mechanisms.length
+            priority: priority
         });
         // We want mechanisms with highest priority at the start of the list
         this.mechanisms.sort((a, b) => b.priority - a.priority);

--- a/test/sasl/factory.ts
+++ b/test/sasl/factory.ts
@@ -1,0 +1,29 @@
+import * as SASL from '../../src/lib/sasl';
+
+test('SASL - Factory.register should sort by priority', () => {
+    const factory = new SASL.Factory();
+
+    factory.register('EXTERNAL', SASL.EXTERNAL, 1000);
+    factory.register('SCRAM-SHA-1-PLUS', SASL.SCRAM, 250);
+    factory.register('SCRAM-SHA-256-PLUS', SASL.SCRAM, 350);
+    factory.register('SCRAM-SHA-256', SASL.SCRAM, 300);
+    factory.register('SCRAM-SHA-1', SASL.SCRAM, 200);
+    factory.register('X-OAUTH2', SASL.PLAIN, 50);
+    factory.register('DIGEST-MD5', SASL.DIGEST, 100);
+    factory.register('ANONYMOUS', SASL.ANONYMOUS, 0);
+    factory.register('OAUTHBEARER', SASL.OAUTH, 100);
+    factory.register('PLAIN', SASL.PLAIN, 1);
+
+    expect(factory['mechanisms']).toEqual([
+        { name: 'EXTERNAL', constructor: expect.anything(), priority: 1000 },
+        { name: 'SCRAM-SHA-256-PLUS', constructor: expect.anything(), priority: 350 },
+        { name: 'SCRAM-SHA-256', constructor: expect.anything(), priority: 300 },
+        { name: 'SCRAM-SHA-1-PLUS', constructor: expect.anything(), priority: 250 },
+        { name: 'SCRAM-SHA-1', constructor: expect.anything(), priority: 200 },
+        { name: 'DIGEST-MD5', constructor: expect.anything(), priority: 100 },
+        { name: 'OAUTHBEARER', constructor: expect.anything(), priority: 100 },
+        { name: 'X-OAUTH2', constructor: expect.anything(), priority: 50 },
+        { name: 'PLAIN', constructor: expect.anything(), priority: 1 },
+        { name: 'ANONYMOUS', constructor: expect.anything(), priority: 0 }
+    ]);
+});


### PR DESCRIPTION
Our system supports ANONYMOUS and PLAIN. It took me some time to figure out why it was using the wrong mechanism. It's because when the ANONYMOUS mechanism gets registered ([here](https://github.com/legastero/stanza/blob/c16c01ed266f9f47ee68ff35a1e0b42a760a4466/src/Client.ts#L59)), it has a priority of `0` which was getting changed to `mechanisms.length`, making it a higher priority than PLAIN. Since `priority` is a required param for the register method, I didn't see the point of defaulting it.