### PR TITLE
fix(muc): do not rejoin rooms on stream:management:resumed

### DIFF
--- a/src/plugins/muc.ts
+++ b/src/plugins/muc.ts
@@ -128,7 +128,6 @@ export default function (client: Agent) {
         }
     }
     client.on('session:started', rejoinRooms);
-    client.on('stream:management:resumed', rejoinRooms);
 
     client.on('message', msg => {
         if (msg.type === 'groupchat' && msg.hasSubject) {


### PR DESCRIPTION
There's no need to rejoin any already joined MUC rooms upon session resume, because the user should still be inside those rooms. That's entire reason for doing SM resume - to avoid having to rebuild the session's state when connection drops.