### PR TITLE
fix(Client): clear reconnectTimer

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -389,6 +389,7 @@ export default class Client extends EventEmitter {
 
     public async disconnect() {
         this.sessionTerminating = true;
+        clearTimeout(this.reconnectTimer);
         this.outgoingDataQueue.pause();
         if (this.sessionStarted && !this.sm.started) {
             // Only emit session:end if we had a session, and we aren't using


### PR DESCRIPTION
The reconnectTimer must be cleared on disconnect or otherwise the connection will be restarted in a case where disconnect is called after reconnect timer was scheduled.