### PR TITLE
fix(websocket): explicitly close WebSocket on unclean disconnect

### DIFF
--- a/src/plugins/connection.ts
+++ b/src/plugins/connection.ts
@@ -119,7 +119,7 @@ export default function (client: Agent) {
                     });
                     if (client.transport) {
                         client.transport.hasStream = false;
-                        client.transport.disconnect();
+                        client.transport.disconnect(false);
                     }
                 }
             }

--- a/src/transports/websocket.ts
+++ b/src/transports/websocket.ts
@@ -127,6 +127,10 @@ export default class WSConnection extends Duplex implements Transport {
             this.stream = undefined;
             if (this.socket) {
                 this.end();
+                this.socket.close();
+                if (this.client.transport === this) {
+                    this.client.emit('--transport-disconnected');
+                }
             }
             this.socket = undefined;
         }


### PR DESCRIPTION
...and follow up with the --transport-disconnected event.

In case keep alive timeout occurs it calls disconnect, but that
has no real effect without closing the websocket.

@legastero thanks for merging my other PRs! I really like the library, especially it's nice and clean API.

To give some more context on this case. I have enabled keep alives and was trying to rely on them to detect a dead Webocket(dead TCP) connection. This can be tested by having keep alives enabled and then disconnecting ethernet cable and switching over to wifi for example (on Mac Catalina). Probably it could reproduce on some OSes when switching VPNs etc.

Without this change the problem is that even though the timeout error is logged the connection is not really closed. It takes quite more time for the 'on ended' event to occur and I'm not sure if the call to [this.end] has any effect on that - I suspect it just gets closed by the OS.

Maybe there's a better way of fixing this. I don't fully understand node streams, but I would expect that the call to `this.end` was supposed to follow up with the `on end` event, but that's not happening.

[this.end]: https://github.com/legastero/stanza/compare/master...vowel-com:ws-close-on-timeout?expand=1#diff-8516aabfa53f8fa1cddae5decb8a8c695d361244ace4cf85b5ffc9567cce6b26R129