### PR TITLE
"maxHoldOpen" has been made modifiable.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -250,6 +250,7 @@ export interface TransportConfig {
     rid?: number;
     maxRetries?: number;
     wait?: number;
+    maxHoldOpen?: number;
 }
 
 export { Client, Constants, JXT, JID, Namespaces, Stanzas, Jingle, Utils, RTT, LibSASL as SASL };

--- a/src/transports/bosh.ts
+++ b/src/transports/bosh.ts
@@ -196,6 +196,9 @@ export default class BOSH extends Duplex implements Transport {
         if (opts.wait) {
             this.maxWaitTime = opts.wait;
         }
+        if (opts.maxHoldOpen) {
+            this.maxHoldOpen = opts.maxHoldOpen;
+        }
 
         if (this.sid) {
             this.hasStream = true;


### PR DESCRIPTION
I was using version 8.4.13 of stanza. I had to update the Stanza but it acted like it hadn't behaved before. The messages I sent were waiting for the previous request to finish (for Openfire). Therefore, I looked at the differences between them and realized that the "hold" value was "2" in the bosh request. However, it used to be "1". And, when I set this to 1, it was worked.

At the same time, when I sent more than one presence package at the same time, it generates a "bosh" request. However, it now creates a separate bosh request for each presence. I'm asking because I can't understand how to fix this. Thank you.