### PR TITLE
fix: use new random message ID 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,8 +11,7 @@ module.exports = {
         'eslint:recommended',
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
-        'prettier',
-        'prettier/@typescript-eslint'
+        'prettier'
     ],
     rules: {
         '@typescript-eslint/no-explicit-any': 'off',

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -28,7 +28,7 @@ export default class Client extends EventEmitter {
     public sessionStarting?: boolean;
     public sessionStarted?: boolean;
     public sessionTerminating?: boolean;
-    public reconnectAttempts: number = 0;
+    public reconnectAttempts = 0;
 
     public transports: {
         [key: string]: new (

--- a/src/plugins/messaging.ts
+++ b/src/plugins/messaging.ts
@@ -240,7 +240,6 @@ export default function (client: Agent) {
             }
 
             client.sendMessage({
-                id: msg.id,
                 receipt: canSendReceipt ? {
                     id: msg.id,
                     type: 'received'

--- a/src/plugins/pubsub.ts
+++ b/src/plugins/pubsub.ts
@@ -15,7 +15,6 @@ import {
     PubsubEventItems,
     PubsubEventPurge,
     PubsubEventSubscription,
-    PubsubFetch,
     PubsubFetchResult,
     PubsubItem,
     PubsubItemContent,

--- a/test/jxt/sanitizer.ts
+++ b/test/jxt/sanitizer.ts
@@ -3,10 +3,6 @@ import expect from 'expect';
 import * as JXT from '../../src/jxt';
 import { NS_XHTML } from '../../src/Namespaces';
 
-interface Data {
-    body?: JXT.XMLElement;
-}
-
 function setup(): JXT.Registry {
     const registry = new JXT.Registry();
 


### PR DESCRIPTION
Do not reuse the ID from the message we're acknowledging its reception
or marker status.

The outgoing message must use a new ID.