### PR TITLE
bump async to fix browser throttling

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "@types/punycode": "^2.1.0",
         "@types/readable-stream": "^2.3.9",
         "@types/ws": "^7.4.0",
-        "async": "^3.0.1",
+        "async": "^3.2.1",
         "buffer": "^6.0.3",
         "node-fetch": "^2.6.1",
         "process": "^0.11.10",


### PR DESCRIPTION
the async library's `priorityQueue` uses `setImmediate()` in the browser. Set immediate doesn't actually exist in browsers and so it falls back to `setTimeout(fn, 0)`. We noticed that when trying to do webrtc our sending of ice candidates was getting throttled if the tab/browser wasn't visible. We were able to track the problem down to the async library and get a fix pr'd and released. Here more information on how the browser throttling works: https://developer.chrome.com/blog/timer-throttling-in-chrome-88/

This pr just bump async to use the latest version which uses `queueMicrotask()` instead of `setTimeout()` for `setImmediate()`.