### PR TITLE
fix(muc): message with body and subject isn't subject change

### DIFF
--- a/src/plugins/muc.ts
+++ b/src/plugins/muc.ts
@@ -130,7 +130,7 @@ export default function (client: Agent): void {
     client.on('session:started', rejoinRooms);
 
     client.on('message', msg => {
-        if (msg.type === 'groupchat' && msg.hasSubject) {
+        if (msg.type === 'groupchat' && msg.hasSubject && !msg.body) {
             client.emit('muc:topic', {
                 from: msg.from,
                 room: JID.toBare(msg.from),

--- a/test/muc/messages.ts
+++ b/test/muc/messages.ts
@@ -40,6 +40,32 @@ test('MUC subject', () => {
     client.emit('message', incoming);
 });
 
+test('MUC message with body and subject', () => {
+    const client = createClient({});
+
+    const incoming: ReceivedMessage = {
+        body: 'Message body.',
+        hasSubject: true,
+        from: 'room@rooms.test/admin',
+        to: 'tester@localhost',
+        subject: 'Message subject',
+        type: 'groupchat'
+    };
+
+    // XEP-0045 section 7.2.15: "Note: In accordance with the core definition of XML stanzas, any
+    // message can contain a <subject/> element; only a message that contains a <subject/> but no
+    // <body/> element shall be considered a subject change for MUC purposes.
+    const callback = jest.fn()
+    client.on('muc:topic', callback);
+
+    client.on('groupchat', msg => {
+        expect(msg).toStrictEqual(incoming);
+    });
+
+    client.emit('message', incoming);
+    expect(callback).not.toHaveBeenCalled();
+});
+
 test('MUC empty subject', () => {
     const client = createClient({});
 


### PR DESCRIPTION
XEP-0045 "Multi-User Chat" section 7.2.15 "Room Subject" states:

> Note: In accordance with the core definition of XML stanzas, any message can contain a
> <subject/> element; only a message that contains a <subject/> but no <body/> element
> shall be considered a subject change for MUC purposes.

See: https://xmpp.org/extensions/xep-0045.html#enter-subject

Stanza currently emits the 'muc:topic' event for any groupchat message that has a subject.
This should only occur for stanzas that have _no_ body.

This commit adds a test and a functional change to this effect.