### PR TITLE
Reset handled counter only for enable stanzas

### DIFF
--- a/src/helpers/StreamManagement.ts
+++ b/src/helpers/StreamManagement.ts
@@ -175,8 +175,13 @@ export default class StreamManagement extends EventEmitter {
         kind: string,
         stanza: StreamManagementEnable | StreamManagementResume | Message | Presence | IQ
     ): Promise<boolean> {
-        if (kind === 'sm' && (stanza.type === 'enable' || stanza.type === 'resume')) {
-            this.handled = 0;
+        const isStanzaEnable = stanza.type === 'enable';
+
+        if (kind === 'sm' && (isStanzaEnable || stanza.type === 'resume')) {
+            if (isStanzaEnable) {
+                this.handled = 0;
+            }
+
             this.outboundStarted = true;
 
             await this._cache();


### PR DESCRIPTION
This merge request is fixing Stream management bug which causes getting duplicated stanzas after resuming session.

If session was resumed - stanza resume was sent with h set to last h value from previous session - counter for handled stanzas is set to 0. Because of this reset, xmpp server is sending every stanza until client reach the h number from last session.

Example: before disconnection, on the client side, h is 20, and on the server side, h is also set to 20. The client loses connection with the server, after which it is restored. Resume stanza is sent with h of 20, then h is reset to 0. The server then sends 20 stanzas to the client, which are marked as delayed.