### PR TITLE
Must evaluate 'resume' in SM 'enabled' response

### DIFF
--- a/src/helpers/StreamManagement.ts
+++ b/src/helpers/StreamManagement.ts
@@ -98,6 +98,7 @@ export default class StreamManagement extends EventEmitter {
 
     public async enabled(resp: StreamManagementEnabled): Promise<void> {
         this.id = resp.id;
+        this.allowResume = resp.resume || false;
         this.handled = 0;
         this.inboundStarted = true;
 

--- a/test/stream-management.ts
+++ b/test/stream-management.ts
@@ -1,5 +1,41 @@
 import StreamManagement from '../src/helpers/StreamManagement';
 
+test('Failed response to enable request', async () => {
+    const sm = new StreamManagement();
+    await sm.enable();
+    await sm.track('sm', { type: 'enable' });
+    await sm.failed( { type: 'failed'});
+    expect(sm.started).toStrictEqual(false);
+    expect(sm.resumable).toStrictEqual(false);
+});
+
+test('Enabled response without resume attribute', async () => {
+    const sm = new StreamManagement();
+    await sm.enable();
+    await sm.track('sm', { type: 'enable' });
+    await sm.enabled({ id: 'test', type: 'enabled' });
+    expect(sm.started).toStrictEqual(true);
+    expect(sm.resumable).toStrictEqual(false);
+});
+
+test('Enabled response with positive resume attribute', async () => {
+    const sm = new StreamManagement();
+    await sm.enable();
+    await sm.track('sm', { type: 'enable' });
+    await sm.enabled({ id: 'test', resume: true, type: 'enabled' });
+    expect(sm.started).toStrictEqual(true);
+    expect(sm.resumable).toStrictEqual(true);
+});
+
+test('Enabled response with negative resume attribute', async () => {
+    const sm = new StreamManagement();
+    await sm.enable();
+    await sm.track('sm', { type: 'enable' });
+    await sm.enabled({ id: 'test', resume: false, type: 'enabled' });
+    expect(sm.started).toStrictEqual(true);
+    expect(sm.resumable).toStrictEqual(false);
+});
+
 test('Handled unacked on resume', async () => {
     let cache: any;
     const acked: any[] = [];


### PR DESCRIPTION
Consider this exchange between a stanza.io client, and a server. It shows the client enabling stream management, as described in [section 3 of XEP-0198](https://xmpp.org/extensions/xep-0198.html#enable).

raw:outgoing: `<enable xmlns="urn:xmpp:sm:3" resume="1"/>`
raw:incoming: `<enabled xmlns="urn:xmpp:sm:3"/>`

Here, the client indicates that wants to be allowed to resume a previous setting, by including a boolean 'resume' attribute.

When the server allows for Ack-ing functionality, but does not support then Resumption functionality, it is allowed to respond with an `<enabled>` element that does not include the `resume` attribute (or possibly with a falsy attribute value).

Stanza.io should, in this case, not mark the stream to be resumable, but, prior to this commit, it does.

This commit adds unit tests for this scenario and modifies the processing of the `<enabled>` response. It now explicitly evaluates the `resume` attribute of the `<enabled>` response.
