### PR TITLE
Improvements for the GitHub CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
     build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [12.x, 14.x, 16.x]
+                node-version: [lts/Erbium, lts/Fermium, lts/Gallium]
 
         steps:
             - uses: actions/checkout@v4
@@ -16,6 +16,7 @@ jobs:
               uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-version }}
+                  check-latest: true
             - run: npm install
             - run: npm run lint
             - run: npm run compile

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,9 +11,9 @@ jobs:
                 node-version: [12.x, 14.x, 16.x]
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v1
+              uses: actions/setup-node@v3
               with:
                   node-version: ${{ matrix.node-version }}
             - run: npm install

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [lts/Erbium, lts/Fermium, lts/Gallium]
+                node-version: [lts/Erbium, lts/Fermium, lts/Gallium, lts/Hydrogen]
 
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Minor improvements:
- bumps version numbers of Github Actions that are used to implement the workflow
- workflow now runs on PR requests too
- adds nodejs 18 (which is a newer LTS release)
- always builds against the latest version of each LTS release