### PR TITLE
Upgrade typescript from 4.2.4 to 4.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "ts-jest": "^27.0.5",
         "ts-node": "^10.2.1",
         "typedoc": "^0.21.9",
-        "typescript": "^4.2.4",
+        "typescript": "^4.4.3",
         "webpack": "^5.72.1",
         "webpack-bundle-analyzer": "^4.4.0",
         "webpack-cli": "^4.5.0"


### PR DESCRIPTION
This intends to prevent the following compilation error:

```
$ npm run compile

> stanza@12.19.1 compile
> tsc -p .

node_modules/@types/babel__traverse/index.d.ts:326:10 - error TS1023: An index signature parameter type must be either 'string' or 'number'.

326         [k: `${string}|${string}`]: VisitNode<S, Node>;
             ~


Found 1 error.
```

Inspiration for this change was taken from https://github.com/DefinitelyTyped/DefinitelyTyped/issues/65766

@legastero please be aware that I'm out of my depth here. I'm suggesting this change without truly understanding the problem that it apparently fixes. Please review carefully.