### PR TITLE
feat: add raw:incoming:rid, fix: add transport config as object.

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -321,6 +321,14 @@ export default class Client extends EventEmitter {
             super.emit(`raw:${args[0]}`, args[1]);
             super.emit('raw:*', `raw:${args[0]}`, args[1]);
             super.emit('*', `raw:${args[0]}`, args[1]);
+        } else if (name === 'raw:incoming:*') {
+            super.emit(`raw:incoming:${args[0]}`, args[1]);
+            super.emit('raw:*', `raw:incoming:${args[0]}`, args[1]);
+            super.emit('*', `raw:incoming:${args[0]}`, args[1]);
+        } else if (name === 'raw:outgoing:*') {
+            super.emit(`raw:outgoing:${args[0]}`, args[1]);
+            super.emit('raw:*', `raw:outgoing:${args[0]}`, args[1]);
+            super.emit('*', `raw:outgoing:${args[0]}`, args[1]);
         } else {
             super.emit('*', name, ...args);
         }
@@ -404,6 +412,11 @@ export default class Client extends EventEmitter {
                     }
                     config.url = endpoints[name][0];
                 }
+            } else if (typeof settings === "object") {
+                config = {
+                    ...config,
+                    ...settings,
+                };
             }
 
             this.transport = transport;

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,8 @@ export interface AgentEvents {
 
     'raw:incoming': string;
     'raw:outgoing': string;
+    'raw:incoming:*': (rid: string, data: string) => void;
+    'raw:outgoing:*': (rid: string, data: string) => void;
     'raw:*': (direction: 'incoming' | 'outgoing', data: string) => void;
     raw: (direction: 'incoming' | 'outgoing', data: string) => void;
 

--- a/src/transports/bosh.ts
+++ b/src/transports/bosh.ts
@@ -286,10 +286,12 @@ export default class BOSH extends Duplex implements Transport {
         }
 
         this.client.emit('raw', 'outgoing', body);
+        this.client.emit('raw:outgoing:*', rid.toString(), body);
 
         this.sendingChannel
             .send(rid, body)
             .then(result => {
+                this.client.emit('raw:incoming:*', rid.toString(), body);
                 this.process(result);
             })
             .catch(err => {
@@ -312,10 +314,12 @@ export default class BOSH extends Duplex implements Transport {
             .toString();
 
         this.client.emit('raw', 'outgoing', body);
+        this.client.emit('raw:outgoing:*', rid.toString(), body);
 
         this.pollingChannel
             .send(rid, body)
             .then(result => {
+                this.client.emit('raw:incoming:*', rid.toString(), body);
                 this.process(result);
             })
             .catch(err => {


### PR DESCRIPTION
Our company used to use raw:incoming:RID but right now this feature removed. You can see it in this link: #251 
Besides that we are also used to use maxHoldOpen, it also removed. You can see it in this link: #486 
Unfortunately maxHoldOpen not working and this PR fixes all these issues.