### PR TITLE
add @types/node-fetch as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "@types/async": "^3.2.5",
         "@types/node": "^14.14.36",
+        "@types/node-fetch": "^2.6.11",
         "@types/punycode": "^2.1.0",
         "@types/ws": "^7.4.0",
         "async": "^3.2.1",


### PR DESCRIPTION
I was obtaining this error:

```
✘ [ERROR] TS7016: Could not find a declaration file for module 'node-fetch'. '/home/andres/c2c-angular/node_modules/node-fetch/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/node-fetch` if it exists or add a new declaration (.d.ts) file containing `declare module 'node-fetch';` [plugin angular-compiler]

    node_modules/stanza/platform/node/index.d.ts:2:18:
      2 │ import fetch from 'node-fetch';
        ╵                   ~~~~~~~~~~~~
```

And including @types/node-fetch in dependencies fixes it. I think it makes sense including `types` for that dependency the same way are being included for the rest of them.